### PR TITLE
Map vips_rotate Operation in VipsRotateOperation Class

### DIFF
--- a/src/main/java/org/jlibvips/VipsAngle.java
+++ b/src/main/java/org/jlibvips/VipsAngle.java
@@ -29,4 +29,18 @@ public enum VipsAngle {
                 throw new IllegalArgumentException("Allowed VipsAngle's are [0°, 90°, 180°, 270°].");
         }
     }
+
+
+    public double toDouble() {
+        switch (this) {
+            case D90:
+                return 90.0;
+            case D180:
+                return 180.0;
+            case D270:
+                return 270.0;
+            default:
+                return 0.0;
+        }
+    }
 }

--- a/src/main/java/org/jlibvips/VipsImage.java
+++ b/src/main/java/org/jlibvips/VipsImage.java
@@ -305,4 +305,16 @@ public class VipsImage {
         }
         return new VipsImage(out[0]);
     }
+
+    /**
+     * Rotate the image.
+     *
+     * http://libvips.github.io/libvips/API/current/libvips-resample.html#vips-rotate
+     *
+     * @param angle {@link VipsAngle}
+     * @return {@link VipsRotateOperation}
+     */
+    public VipsRotateOperation rotate(VipsAngle angle) {
+        return new VipsRotateOperation(this, angle);
+    }
 }

--- a/src/main/java/org/jlibvips/jna/VipsBindings.java
+++ b/src/main/java/org/jlibvips/jna/VipsBindings.java
@@ -37,4 +37,5 @@ public interface VipsBindings extends Library {
     int vips_embed(Pointer image, Pointer[] out, int x, int y, int width, int height, Object...args);
     int vips_composite2(Pointer base, Pointer overlay, Pointer[] out, int mode, Object...args);
     int vips_merge(Pointer ref, Pointer sec, Pointer[] out, int direction, int dx, int dy, Object...args);
+    int vips_rotate(Pointer in, Pointer[] out, double angle, Object...args);
 }

--- a/src/main/java/org/jlibvips/operations/VipsRotateOperation.java
+++ b/src/main/java/org/jlibvips/operations/VipsRotateOperation.java
@@ -1,0 +1,74 @@
+package org.jlibvips.operations;
+
+import com.sun.jna.Pointer;
+import org.jlibvips.VipsAngle;
+import org.jlibvips.VipsImage;
+import org.jlibvips.exceptions.VipsException;
+import org.jlibvips.jna.VipsBindingsSingleton;
+import org.jlibvips.util.Varargs;
+
+import java.util.List;
+
+/**
+ * Rotates the given {@link org.jlibvips.VipsImage} by the {@link org.jlibvips.VipsAngle}.
+ *
+ * @author codecitizen
+ */
+public class VipsRotateOperation {
+
+    private final VipsImage image;
+    private final VipsAngle angle;
+
+    private Pointer background;
+    private Double idx,idy,odx,ody;
+
+    public VipsRotateOperation(VipsImage image, VipsAngle angle) {
+        this.image = image;
+        this.angle = angle;
+    }
+
+    public VipsImage create() {
+        Pointer[] out = new Pointer[1];
+        int ret = VipsBindingsSingleton.instance().vips_rotate(image.getPtr(), out, angle.toDouble(),
+                new Varargs()
+                        .add("background", background)
+                        .add("idx", idx)
+                        .add("idy", idy)
+                        .add("odx", odx)
+                        .add("ody", ody).toArray());
+        if(ret != 0) {
+            throw new VipsException("vips_rotate", ret);
+        }
+        return new VipsImage(out[0]);
+    }
+
+    public VipsRotateOperation withIdx(double idx) {
+        this.idx = idx;
+        return this;
+    }
+
+    public VipsRotateOperation withIdy(double idy) {
+        this.idy = idy;
+        return this;
+    }
+
+    public VipsRotateOperation withOdx(double odx) {
+        this.odx = odx;
+        return this;
+    }
+
+    public VipsRotateOperation withOdy(double ody) {
+        this.ody = ody;
+        return this;
+    }
+
+    public VipsRotateOperation background(List<Float> background) {
+        return background(background != null? background.stream().mapToDouble(Float::doubleValue).toArray() : null);
+    }
+
+    public VipsRotateOperation background(double[] background) {
+        this.background = background != null?
+                VipsBindingsSingleton.instance().vips_array_double_new(background, background.length) : null;
+        return this;
+    }
+}

--- a/src/test/groovy/org/jlibvips/operations/VipsRotateOperationSpec.groovy
+++ b/src/test/groovy/org/jlibvips/operations/VipsRotateOperationSpec.groovy
@@ -1,0 +1,35 @@
+package org.jlibvips.operations
+
+import org.jlibvips.VipsAngle
+import org.jlibvips.VipsImage
+import org.jlibvips.jna.VipsBindingsSingleton
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+import static org.jlibvips.TestUtils.copyResourceToFS
+
+class VipsRotateOperationSpec extends Specification {
+
+    def setupSpec() {
+        VipsBindingsSingleton.configure("libvips.42.dylib")
+    }
+
+    def "Rotate a PNG by various angles."() {
+        given:
+        def file = copyResourceToFS "1920x1080.png"
+        def image = VipsImage.fromFile(file)
+        when:
+        def rotateImage = image.rotate(angle).create()
+        then:
+        rotateImage.width == expectedWith
+        rotateImage.height == expectedHeight
+        cleanup:
+        Files.deleteIfExists file
+        where:
+        angle << [VipsAngle.D0, VipsAngle.D90, VipsAngle.D180, VipsAngle.D270]
+        expectedWith << [1920, 1080, 1920, 1080]
+        expectedHeight << [1080, 1920, 1080, 1920]
+    }
+
+}


### PR DESCRIPTION
Mapping the [vips_rotate](http://libvips.github.io/libvips/API/current/libvips-resample.html#vips-rotate) operation. Did not add support for `interpolate` parameter, since mapping the [struct](http://libvips.github.io/libvips/API/current/VipsInterpolate.html) would require deeper JNA integrations, not feasible now. 