### PR TITLE
Enable GLib Logging for Libvips

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,57 @@ public class ImagePyramidExample {
     
 }
 ```
+
+**Example: Logging**
+
+```java
+package jlibvips.example;
+
+import org.jlibvips.*;
+import org.jlibvips.jna.glib.*;
+import java.util.List;
+
+public class LoggingExample {
+  public static void main(String[] args) {
+    // 1) Configure GLib JNA Mappings
+    GLibBindingsSingleton.configure("path/to/glibc");
+    // 2) Register Log Handler
+    VipsImage.registerLogHandler(
+            List.of(GLogLevelFlags.G_LOG_LEVEL_INFO,
+                    GLogLevelFlags.G_LOG_LEVEL_DEBUG),
+            (flag, message) -> System.out.printf("VIPS[%s]: %s", flag, message)
+    );
+    var image = VipsImage.formPdf(Paths.get(args[0]), 0); // Second Parameter is the Page Number
+    var thumbnail = image.thumbnail()
+        .autoRotate()
+        .create();
+    thumbnail.jpeg()
+        .quality(100)
+        .strip()
+        .save();
+  }
+}
+```
+
+Should deliver an Output like:
+
+```
+VIPS[G_LOG_LEVEL_INFO]: selected loader is image source
+VIPS[G_LOG_LEVEL_INFO]: input size is 500 x 500
+VIPS[G_LOG_LEVEL_INFO]: converting to processing space scrgb
+VIPS[G_LOG_LEVEL_INFO]: shrinkv by 2
+VIPS[G_LOG_LEVEL_INFO]: shrinkh by 2
+VIPS[G_LOG_LEVEL_INFO]: residual reducev by 0.4
+VIPS[G_LOG_LEVEL_INFO]: reducev: 16 point mask
+VIPS[G_LOG_LEVEL_INFO]: residual reduceh by 0.4
+VIPS[G_LOG_LEVEL_INFO]: reduceh: 16 point mask
+VIPS[G_LOG_LEVEL_INFO]: cropping to 100x100
+VIPS[G_LOG_LEVEL_INFO]: convi: using C path
+VIPS[G_LOG_LEVEL_INFO]: residual reducev by 0.32
+VIPS[G_LOG_LEVEL_INFO]: reducev: 7 point mask
+VIPS[G_LOG_LEVEL_INFO]: residual reduceh by 0.32
+VIPS[G_LOG_LEVEL_INFO]: reduceh: 7 point mask
+VIPS[G_LOG_LEVEL_INFO]: gaussblur mask width 17
+VIPS[G_LOG_LEVEL_INFO]: convi: using C path
+VIPS[G_LOG_LEVEL_INFO]: convi: using C path
+```

--- a/src/main/java/org/jlibvips/VipsImage.java
+++ b/src/main/java/org/jlibvips/VipsImage.java
@@ -102,11 +102,17 @@ public class VipsImage {
         return new VipsImage(ptr);
     }
 
-    public static void registerLogHandler(List<GLogLevelFlags> levels, BiConsumer<Integer,String> loggingFunction) {
-        int flags = Arrays.stream(GLogLevelFlags.values())
+  /**
+   * Registers a new logging handler for the libvips GLib logs.
+   *
+   * @param levels the subscribed {@link org.jlibvips.jna.glib.GLogLevelFlags}.
+   * @param loggingFunction the logging function taking the flag as first and log message as second parameter.
+   */
+    public static void registerLogHandler(List<GLogLevelFlags> levels, BiConsumer<GLogLevelFlags,String> loggingFunction) {
+        int flags = levels.stream()
                 .map(GLogLevelFlags::getVal)
                 .reduce((l1, l2) -> l1 | l2).orElse(GLogLevelFlags.G_LOG_LEVEL_DEBUG.getVal());
-        GLibLogHandler handler = (d, f, m, p) -> loggingFunction.accept(f, m);
+        GLibLogHandler handler = (d, f, m, p) -> loggingFunction.accept(GLogLevelFlags.fromVal(f), m);
         GLibBindingsSingleton.instance()
                 .g_log_set_handler("VIPS", flags, handler, null);
     }

--- a/src/main/java/org/jlibvips/VipsImage.java
+++ b/src/main/java/org/jlibvips/VipsImage.java
@@ -317,4 +317,8 @@ public class VipsImage {
     public VipsRotateOperation rotate(VipsAngle angle) {
         return new VipsRotateOperation(this, angle);
     }
+
+    public SimilarityOperation similarity() {
+        return new SimilarityOperation(this);
+    }
 }

--- a/src/main/java/org/jlibvips/exceptions/VipsException.java
+++ b/src/main/java/org/jlibvips/exceptions/VipsException.java
@@ -11,6 +11,12 @@ public class VipsException extends RuntimeException {
         this.returnValue = returnValue;
     }
 
+    public VipsException(String operation, Throwable cause) {
+        super(String.format("VipsBindings operation %s failed with Exception.", operation), cause);
+        this.operation = operation;
+        this.returnValue = -1;
+    }
+
     public String getOperation() {
         return operation;
     }

--- a/src/main/java/org/jlibvips/jna/VipsBindings.java
+++ b/src/main/java/org/jlibvips/jna/VipsBindings.java
@@ -38,4 +38,5 @@ public interface VipsBindings extends Library {
     int vips_composite2(Pointer base, Pointer overlay, Pointer[] out, int mode, Object...args);
     int vips_merge(Pointer ref, Pointer sec, Pointer[] out, int direction, int dx, int dy, Object...args);
     int vips_rotate(Pointer in, Pointer[] out, double angle, Object...args);
+    int vips_similarity(Pointer in, Pointer[] out, Object...args);
 }

--- a/src/main/java/org/jlibvips/jna/VipsBindingsSingleton.java
+++ b/src/main/java/org/jlibvips/jna/VipsBindingsSingleton.java
@@ -5,7 +5,7 @@ import com.sun.jna.Native;
 public class VipsBindingsSingleton {
 
 
-    private static String libraryPath = "";
+    private static String libraryPath = "/usr/local/Cellar/vips/8.7.0/lib/libvips.42.dylib";
 
     public static void configure(String lp) {
         libraryPath = lp;

--- a/src/main/java/org/jlibvips/jna/glib/GLibBindings.java
+++ b/src/main/java/org/jlibvips/jna/glib/GLibBindings.java
@@ -1,0 +1,25 @@
+package org.jlibvips.jna.glib;
+
+import com.sun.jna.Callback;
+import com.sun.jna.Library;
+import com.sun.jna.Pointer;
+
+public interface GLibBindings extends Library {
+
+  /**
+   * Sets the log handler for a domain and a set of log levels. To handle fatal and recursive messages the log_levels
+   * parameter must be combined with the G_LOG_FLAG_FATAL and G_LOG_FLAG_RECURSION bit flags.
+   * <a href="https://developer.gnome.org/glib/stable/glib-Message-Logging.html#g-log-set-handler">GLib Reference Manual Docs.</a>
+   *
+   * @param log_domain the log domain, or NULL for the default "" application domain.
+   * @param log_levels the log levels to apply the log handler for. To handle fatal and recursive messages as well,
+   *                   combine the log levels with the G_LOG_FLAG_FATAL and G_LOG_FLAG_RECURSION bit flags.
+   * @param log_func the log handler function
+   * @param user_data data passed to the log handler
+   * @return the id of the new handler
+   */
+  int g_log_set_handler(String log_domain, int log_levels, Callback log_func, Pointer user_data);
+
+  void g_log(String log_domain, int log_levels, String format, Object...args);
+
+}

--- a/src/main/java/org/jlibvips/jna/glib/GLibBindingsSingleton.java
+++ b/src/main/java/org/jlibvips/jna/glib/GLibBindingsSingleton.java
@@ -4,11 +4,17 @@ import com.sun.jna.Native;
 
 public class GLibBindingsSingleton {
 
+  private static String libraryPath = "/usr/local/Cellar/glib/2.58.1/lib/libglib-2.0.0.dylib";
+
+  public static void configure(String lp) {
+    libraryPath = lp;
+  }
+
   private static GLibBindings INSTANCE;
 
   public static GLibBindings instance() {
     if(INSTANCE == null) {
-      INSTANCE = Native.load("/usr/local/Cellar/glib/2.58.1/lib/libglib-2.0.0.dylib", GLibBindings.class);
+      INSTANCE = Native.load(libraryPath, GLibBindings.class);
     }
     return INSTANCE;
   }

--- a/src/main/java/org/jlibvips/jna/glib/GLibBindingsSingleton.java
+++ b/src/main/java/org/jlibvips/jna/glib/GLibBindingsSingleton.java
@@ -1,0 +1,19 @@
+package org.jlibvips.jna.glib;
+
+import com.sun.jna.Native;
+
+public class GLibBindingsSingleton {
+
+  private static GLibBindings INSTANCE;
+
+  public static GLibBindings instance() {
+    if(INSTANCE == null) {
+      INSTANCE = Native.load("/usr/local/Cellar/glib/2.58.1/lib/libglib-2.0.0.dylib", GLibBindings.class);
+    }
+    return INSTANCE;
+  }
+
+  private GLibBindingsSingleton() {
+  }
+
+}

--- a/src/main/java/org/jlibvips/jna/glib/GLibLogHandler.java
+++ b/src/main/java/org/jlibvips/jna/glib/GLibLogHandler.java
@@ -1,0 +1,10 @@
+package org.jlibvips.jna.glib;
+
+import com.sun.jna.Callback;
+import com.sun.jna.Pointer;
+
+public interface GLibLogHandler extends Callback {
+
+  void log(String log_domain, int flags, String message, Pointer pointer);
+
+}

--- a/src/main/java/org/jlibvips/jna/glib/GLogLevelFlags.java
+++ b/src/main/java/org/jlibvips/jna/glib/GLogLevelFlags.java
@@ -1,0 +1,24 @@
+package org.jlibvips.jna.glib;
+
+public enum GLogLevelFlags {
+  /* log flags */
+  G_LOG_FLAG_RECURSION(1 << 0),
+  G_LOG_FLAG_FATAL(1 << 1),
+  /* GLib log levels */
+  G_LOG_LEVEL_ERROR(1 << 2),       /* always fatal */
+  G_LOG_LEVEL_CRITICAL(1 << 3),
+  G_LOG_LEVEL_WARNING (1 << 4),
+  G_LOG_LEVEL_MESSAGE(1 << 5),
+  G_LOG_LEVEL_INFO(1 << 6),
+  G_LOG_LEVEL_DEBUG(1 << 7);
+
+  private final int val;
+
+  GLogLevelFlags(int val) {
+    this.val   = val;
+  }
+
+  public int getVal() {
+    return val;
+  }
+}

--- a/src/main/java/org/jlibvips/jna/glib/GLogLevelFlags.java
+++ b/src/main/java/org/jlibvips/jna/glib/GLogLevelFlags.java
@@ -1,5 +1,7 @@
 package org.jlibvips.jna.glib;
 
+import java.util.Arrays;
+
 public enum GLogLevelFlags {
   /* log flags */
   G_LOG_FLAG_RECURSION(1 << 0),
@@ -10,7 +12,11 @@ public enum GLogLevelFlags {
   G_LOG_LEVEL_WARNING (1 << 4),
   G_LOG_LEVEL_MESSAGE(1 << 5),
   G_LOG_LEVEL_INFO(1 << 6),
-  G_LOG_LEVEL_DEBUG(1 << 7);
+  G_LOG_LEVEL_DEBUG(1 << 7),
+  /**
+   * Not a valid GLohLevelFlags!
+   */
+  G_LOG_LEVEL_UNKNOWN(0);
 
   private final int val;
 
@@ -20,5 +26,12 @@ public enum GLogLevelFlags {
 
   public int getVal() {
     return val;
+  }
+
+  public static GLogLevelFlags fromVal(int val) {
+    return Arrays.stream(GLogLevelFlags.values())
+            .filter(f -> f.getVal() == val)
+            .findAny()
+            .orElse(G_LOG_LEVEL_UNKNOWN);
   }
 }

--- a/src/main/java/org/jlibvips/operations/SimilarityOperation.java
+++ b/src/main/java/org/jlibvips/operations/SimilarityOperation.java
@@ -1,0 +1,39 @@
+package org.jlibvips.operations;
+
+import com.sun.jna.Pointer;
+import org.jlibvips.VipsAngle;
+import org.jlibvips.VipsImage;
+import org.jlibvips.exceptions.VipsException;
+import org.jlibvips.jna.VipsBindingsSingleton;
+import org.jlibvips.util.Varargs;
+
+public class SimilarityOperation {
+
+    private final VipsImage image;
+
+    private VipsAngle angle;
+
+    public SimilarityOperation(VipsImage image) {
+        this.image = image;
+    }
+
+    public VipsImage create() {
+        try {
+            Pointer[] out = new Pointer[1];
+            int ret = VipsBindingsSingleton.instance().vips_similarity(image.getPtr(), out,
+                    new Varargs().add("angle", angle != null ? angle.toDouble() : null).toArray());
+            if (ret == 0) {
+                return new VipsImage(out[0]);
+            } else
+                throw new VipsException("vips_similarity", ret);
+        } catch (Throwable t) {
+            throw new VipsException("vips_similarity", t);
+        }
+    }
+
+    public SimilarityOperation angle(VipsAngle angle) {
+        this.angle = angle;
+        return this;
+    }
+
+}

--- a/src/test/groovy/org/jlibvips/jna/glib/GLibLogging.groovy
+++ b/src/test/groovy/org/jlibvips/jna/glib/GLibLogging.groovy
@@ -1,0 +1,52 @@
+package org.jlibvips.jna.glib
+
+import org.jlibvips.DeepZoomContainer
+import org.jlibvips.DeepZoomLayouts
+import org.jlibvips.VipsAngle
+import org.jlibvips.VipsExtend
+import org.jlibvips.VipsImage
+import spock.lang.Specification
+
+import static org.jlibvips.TestUtils.*
+
+class GLibLogging extends Specification {
+
+    def 'Set GLib Logging Handler'() {
+        given:
+        def glib = GLibBindingsSingleton.instance()
+        def handler = Mock(GLibLogHandler)
+        when:
+        glib.g_log_set_handler("jlibvips", GLogLevelFlags.G_LOG_LEVEL_DEBUG.getVal(), handler, null)
+        glib.g_log("jlibvips", GLogLevelFlags.G_LOG_LEVEL_DEBUG.getVal(), "Hello %s!", "Peter")
+        then:
+        1 * handler.log(*_)
+    }
+
+    def 'Enable Debug Logging for Vips'() {
+        given:
+        VipsImage.registerLogHandler([GLogLevelFlags.G_LOG_LEVEL_DEBUG,
+                                      GLogLevelFlags.G_LOG_LEVEL_ERROR,
+                                      GLogLevelFlags.G_LOG_LEVEL_INFO,
+                                      GLogLevelFlags.G_LOG_LEVEL_MESSAGE,
+                                      GLogLevelFlags.G_LOG_LEVEL_WARNING], { flags, message ->
+            println("LIBVIPSLOG: $message")
+        })
+        when:
+        def file = copyResourceToFS("500x500.jpg")
+        def image = VipsImage.fromFile(file)
+        def outDir = newTempDir()
+        image.deepZoom(outDir)
+                .layout(DeepZoomLayouts.Google)
+                .background([0.0f, 0.0f, 0.0f])
+                .rotate(VipsAngle.D90)
+                .container(DeepZoomContainer.FileSystem)
+                .tileSize(256)
+                .centre()
+                .strip()
+                .suffix(".jpg[Q=85]")
+                .save()
+        then:
+        !outDir.empty
+    }
+
+}


### PR DESCRIPTION
The GLibBindings class is a JNA Mapping for GLib Logging Functions,
e.g. to register a logging handler and log. Since libvips uses
GLib for logging, this mapping is going to be used to redirect
logging output from vips to e.g. java.util.Logger instances.