### PR TITLE
Adds method to unref the `VipsImage`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,14 @@ public class PDFThumbnailExample {
         var thumbnail = image.thumbnail()
             .autoRotate()
             .create();
+        image.unref();
         var thumbnailFile = thumbnail.jpeg()
             .quality(100)
             .strip()
             .save();
-        System.out.printf("Thumbnail generated in '%s'.%n", thumbnailFile.toString());
+        thumbnail.unref();
+        
+        System.out.printf("Thumbnail generated in '%s'.%n", thumbnailFile.toString());                
         System.out.println("Done!");
     }
     
@@ -68,6 +71,7 @@ public class ImagePyramidExample {
             .container(DeepZoomContainer.FileSystem)
             .suffix(".jpg[Q=100]")
             .save();
+        image.unref();
         System.out.printf("Pyramid generated in folder '%s'.%n", directory.toString());
         System.out.println("Done.");
     }
@@ -98,10 +102,12 @@ public class LoggingExample {
     var thumbnail = image.thumbnail()
         .autoRotate()
         .create();
+    image.unref();
     thumbnail.jpeg()
         .quality(100)
         .strip()
         .save();
+    thumbnail.unref();
   }
 }
 ```

--- a/src/main/java/org/jlibvips/VipsImage.java
+++ b/src/main/java/org/jlibvips/VipsImage.java
@@ -355,4 +355,13 @@ public class VipsImage {
     public SimilarityOperation similarity() {
         return new SimilarityOperation(this);
     }
+
+    /**
+     * When you are done with this image, use <code>unref()</code> to dispose of it.
+     *
+     * @see <a href="https://jcupitt.github.io/libvips/API/current/using-from-c.html">Reference counting</a>
+     */
+    public void unref() {
+        VipsBindingsSingleton.instance().g_object_unref(ptr);
+    }
 }

--- a/src/main/java/org/jlibvips/jna/VipsBindings.java
+++ b/src/main/java/org/jlibvips/jna/VipsBindings.java
@@ -41,4 +41,13 @@ public interface VipsBindings extends Library {
     int vips_merge(Pointer ref, Pointer sec, Pointer[] out, int direction, int dx, int dy, Object...args);
     int vips_rotate(Pointer in, Pointer[] out, double angle, Object...args);
     int vips_similarity(Pointer in, Pointer[] out, Object...args);
+
+    /**
+     * When you are done with an image, use <code>g_object_unref()</code> to dispose of it. If you pass an image to an
+     * operation and that operation needs to keep a copy of the image, it will ref it. So you can unref an image as soon
+     * as you no longer need it, you don't need to hang on to it in case anyone else is still using it.
+     *
+     * @see <a href="https://developer.gnome.org/gobject/stable/gobject-The-Base-Object-Type.html#g-object-unref">g_object_unref()</a>
+     */
+    void g_object_unref(Pointer object);
 }

--- a/src/main/java/org/jlibvips/jna/glib/GLibBindingsSingleton.java
+++ b/src/main/java/org/jlibvips/jna/glib/GLibBindingsSingleton.java
@@ -4,7 +4,7 @@ import com.sun.jna.Native;
 
 public class GLibBindingsSingleton {
 
-  private static String libraryPath = "/usr/local/Cellar/glib/2.58.1/lib/libglib-2.0.0.dylib";
+  private static String libraryPath = "/usr/local/opt/glib/lib/libglib-2.0.dylib";
 
   public static void configure(String lp) {
     libraryPath = lp;

--- a/src/test/groovy/org/jlibvips/Drawing.groovy
+++ b/src/test/groovy/org/jlibvips/Drawing.groovy
@@ -29,6 +29,9 @@ class Drawing extends Specification {
         then:
         newImage != null
         cleanup:
+        image.unref()
+        svgImage.unref()
+        newImage.unref()
         Files.deleteIfExists imagePath
     }
 

--- a/src/test/groovy/org/jlibvips/VipsImageSpec.groovy
+++ b/src/test/groovy/org/jlibvips/VipsImageSpec.groovy
@@ -22,6 +22,7 @@ class VipsImageSpec extends Specification {
         image.width == width
         image.height == height
         cleanup:
+        image.unref()
         Files.deleteIfExists(file)
         where:
         resource      | width | height
@@ -37,6 +38,7 @@ class VipsImageSpec extends Specification {
         image.width <= VipsImage.POPPLER_CAIRO_LIMIT
         image.height <= VipsImage.POPPLER_CAIRO_LIMIT
         cleanup:
+        image.unref()
         Files.deleteIfExists(pdfFile)
         where:
         pdfResource | pageNumber
@@ -52,6 +54,7 @@ class VipsImageSpec extends Specification {
         then: "the number of bands is accessible"
         image.bands == bands
         cleanup:
+        image.unref()
         Files.deleteIfExists(file)
         where:
         resource      | bands
@@ -77,6 +80,7 @@ class VipsImageSpec extends Specification {
         then: "generates an image pyramid on the file system"
         Files.exists outDir.resolve("0/0/0.jpg")
         cleanup:
+        image.unref()
         Files.deleteIfExists(file)
         outDir.toFile().deleteDir()
         where:
@@ -99,6 +103,8 @@ class VipsImageSpec extends Specification {
         thumbnail.width == thumbnailWidth
         thumbnail.height == thumbnailHeight
         cleanup:
+        image.unref()
+        thumbnail.unref()
         Files.deleteIfExists file
         where:
         resource      | thumbnailWidth | thumbnailHeight
@@ -122,6 +128,7 @@ class VipsImageSpec extends Specification {
         then: "the resulting image is stored as JPEG to a temporary file location"
         Files.exists jpegFile
         cleanup:
+        image.unref()
         Files.deleteIfExists file
         Files.deleteIfExists jpegFile
         where:
@@ -143,6 +150,7 @@ class VipsImageSpec extends Specification {
         then: "the image is stored as WEBP to a temporary file location"
         Files.exists webpFile
         cleanup:
+        image.unref()
         Files.deleteIfExists file
         Files.deleteIfExists webpFile
         where:
@@ -159,6 +167,7 @@ class VipsImageSpec extends Specification {
         then: "the image is stored in Vips Image Format to a temporary file location"
         Files.exists vFile
         cleanup:
+        image.unref()
         Files.deleteIfExists file
         Files.deleteIfExists vFile
         where:
@@ -174,6 +183,9 @@ class VipsImageSpec extends Specification {
         then: "expect a new image with size 250x250"
         area.width == 250
         area.height == 250
+        cleanup:
+        image.unref()
+        area.unref()
         where:
         resource << ["500x500.jpg"]
     }
@@ -190,6 +202,9 @@ class VipsImageSpec extends Specification {
         then: "expect a image with size 100x50"
         resizedImage.width == 100
         resizedImage.height == 50
+        cleanup:
+        image.unref()
+        resizedImage.unref()
         where:
         resource << ["500x500.jpg"]
     }
@@ -206,6 +221,9 @@ class VipsImageSpec extends Specification {
         then: "expect an image with size 1000x1000"
         extendedImage.width == 1000
         extendedImage.height == 1000
+        cleanup:
+        image.unref()
+        extendedImage.unref()
         where:
         resource << ["500x500.jpg"]
     }

--- a/src/test/groovy/org/jlibvips/operations/Composite2OperationSpec.groovy
+++ b/src/test/groovy/org/jlibvips/operations/Composite2OperationSpec.groovy
@@ -28,6 +28,8 @@ class Composite2OperationSpec extends Specification {
         then:
         println overlayedImage.jpeg().save()
         cleanup:
+        image.unref()
+        overlayedImage.unref()
         Files.deleteIfExists imagePath
         Files.deleteIfExists overlayPath
     }

--- a/src/test/groovy/org/jlibvips/operations/DrawRectOperationSpec.groovy
+++ b/src/test/groovy/org/jlibvips/operations/DrawRectOperationSpec.groovy
@@ -30,6 +30,7 @@ class DrawRectOperationSpec extends Specification {
         then:
         image.bands == 1
         cleanup:
+        image.unref()
         Files.deleteIfExists imagePath
     }
 

--- a/src/test/groovy/org/jlibvips/operations/InsertOperationSpec.groovy
+++ b/src/test/groovy/org/jlibvips/operations/InsertOperationSpec.groovy
@@ -35,6 +35,8 @@ class InsertOperationSpec extends Specification {
         image.width == 2170
         image.height == 1330
         cleanup:
+        smallImage.unref()
+        baseImage.unref()
         Files.deleteIfExists baseImagePath
         Files.deleteIfExists smallImagePath
     }

--- a/src/test/groovy/org/jlibvips/operations/ReduceOperationSpec.groovy
+++ b/src/test/groovy/org/jlibvips/operations/ReduceOperationSpec.groovy
@@ -32,6 +32,7 @@ class ReduceOperationSpec extends Specification {
         image.height == height
         image.width == width
         cleanup:
+        smallImage.unref()
         Files.deleteIfExists smallImagePath
     }
 

--- a/src/test/groovy/org/jlibvips/operations/VipsJoinOperationSpec.groovy
+++ b/src/test/groovy/org/jlibvips/operations/VipsJoinOperationSpec.groovy
@@ -27,6 +27,9 @@ class VipsJoinOperationSpec extends Specification {
         then:
         image != null
         cleanup:
+        image1.unref()
+        image2.unref()
+        image.unref()
         Files.deleteIfExists if1
         Files.deleteIfExists if2
         where:

--- a/src/test/groovy/org/jlibvips/operations/VipsRotateOperationSpec.groovy
+++ b/src/test/groovy/org/jlibvips/operations/VipsRotateOperationSpec.groovy
@@ -25,6 +25,8 @@ class VipsRotateOperationSpec extends Specification {
         rotateImage.width == expectedWith
         rotateImage.height == expectedHeight
         cleanup:
+        image.unref()
+        rotateImage.unref()
         Files.deleteIfExists file
         where:
         angle << [VipsAngle.D0, VipsAngle.D90, VipsAngle.D180, VipsAngle.D270]


### PR DESCRIPTION
When you are done with an image, use `g_object_unref()` to dispose of it

This change adds method `VipsImage.unref()` to dispose the image when it will not be used anymore.